### PR TITLE
Fix broken references

### DIFF
--- a/es6-draft-sections.js
+++ b/es6-draft-sections.js
@@ -203,7 +203,6 @@ var legacy_sections = {
     "sec-identifiers-and-identifier-names-static-semantics-stringvalue": "sec-identifier-names-static-semantics-stringvalue",
     "sec-identity-functions": "sec-promisereactionjob",
     "sec-iloader.prototype.normalize-name-referername-refereraddress": "",
-    "sec-imports-runtime-semantics-evaluation": "#sec-imports",
     "sec-in-edition-5": "",
     "sec-in-edition-5.1": "",
     "sec-in-edition-6": "sec-corrections-and-clarifications-in-edition-6-with-possible-compatibility-impact",

--- a/fixups.py
+++ b/fixups.py
@@ -3092,7 +3092,7 @@ def fixup_links(doc, docx):
 
     all_ids = set([kid.attrs['id'] for _, _, kid in all_parent_index_child_triples(doc) if 'id' in kid.attrs])
 
-    WORD_REF_RE = (r'(?:{ REF \w+ (?:\\r )?\\h(?: +\\\*)?(?: +MERGEFORMAT)? *}'
+    WORD_REF_RE = (r'(?:{ REF \w+ (?:\\[rn] )?\\h(?: +\\\*)?(?: +MERGEFORMAT)? *}'
                    + '\N{LEFT-TO-RIGHT MARK}' + r'?)')
 
     SECTION = r'%s?(%s)' % (


### PR DESCRIPTION
Revision 36 of the ES6 spec (the latest at the time of this writing) includes three references that are not recognized by this script. For example:

![screenshot from 2015-03-24 12 52 17](https://cloud.githubusercontent.com/assets/677252/6807441/df13621e-d224-11e4-8510-75a8c71d8946.png)

I'm not sure if you prefer built changes to be included in pull requests (this might be worth noting in a `CONTRIBUTING.md` file), so I'm playing it safe an omitting them from this patch. I'm happy to include them, though--just let me know. For now, I'll paste a word diff here:

``` diff
$ git diff --word-diff
diff --git a/es6-draft.html b/es6-draft.html
index e65b20e..17473d6 100644
--- a/es6-draft.html
+++ b/es6-draft.html
@@ -32626,13 +32626,14 @@
  <p>Unless otherwise specified, the <code>name</code> property of a built-in Function object, if it exists,  has the attributes
  {&nbsp;[[Writable]]: <b>false</b>, [[Enumerable]]: <b>false</b>, [[Configurable]]: <b>true</b> }.</p>

  <p>Every other data property described in clauses 18 through 26 and in Annex [-{ REF _Ref406169814 \n \h }B.2-]{+<a+}
{+  href="#sec-additional-built-in-properties">B.2</a>+} has the attributes { [[Writable]]: <b>true</b>, [[Enumerable]]: <b>false</b>,
  [[Configurable]]: <b>true</b> } unless otherwise specified.</p>

  <p>Every accessor property described in clauses 18 through 26 and in Annex [-{ REF _Ref406169814 \n \h }B.2-]{+<a href="#sec-additional-built-in-properties">B.2</a>+}
  has the attributes {[[Enumerable]]: <b>false</b>, [[Configurable]]: <b>true</b> } unless otherwise specified. If only a get
  accessor function is described, the set accessor function is the default value, <b>undefined</b>. If only a set accessor is
  described the get accessor is the default value, <b>undefined</b>.</p>
</section>

<section id="sec-global-object">
@@ -45312,8 +45313,8 @@

          <p>If <var>comparefn</var> is not <b>undefined</b> and is not a consistent comparison function for the elements of this
          array (see below), the sort order is implementation-defined. The sort order is also implementation-defined if
          <var>comparefn</var> is <b>undefined</b> and <a href="#sec-sortcompare">SortCompare</a> [-({ REF _Ref393437395 \n \h-]
[-          }22.1.3.24.1)-]{+(<a+}
{+          href="#sec-sortcompare">22.1.3.24.1</a>)+} does not act as a consistent comparison function.</p>

          <p>Let <var>proto</var> be <var>obj</var>.[[GetPrototypeOf]](). If <var>proto</var> is not <b>null</b> and there exists
          an integer <var>j</var> such that all of the conditions below are satisfied then the sort order is
```
